### PR TITLE
useState 실행 시점 변경과 null, undefined 노드 처리

### DIFF
--- a/src/libs/jsx/jsx-runtime.ts
+++ b/src/libs/jsx/jsx-runtime.ts
@@ -28,12 +28,12 @@ export const jsx = {
       node: {
         tag: component,
         props,
-        children: children.map((v) => {
-          if (!checkIsVirtualNode(v)) {
+        children: children.flat(Infinity).map((v) => {
+          if (!checkIsVirtualNode(v as VirtualDOM | VirtualNode)) {
             return { node: v } as VirtualDOM
           }
           return v
-        }),
+        }) as VirtualDOM[],
       },
     }
   },

--- a/src/libs/vtu/createDOM.ts
+++ b/src/libs/vtu/createDOM.ts
@@ -18,6 +18,7 @@ const createDOM = (node: VirtualDOM): HTMLElement | Text => {
         const dataKey = _.camelCase(key.slice(5))
         element.dataset[dataKey] = node.props[key] as string
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-extra-semi
         ;(element as any)[key] = node.props[key]
       }
     }

--- a/src/libs/vtu/createDOM.ts
+++ b/src/libs/vtu/createDOM.ts
@@ -2,9 +2,14 @@ import _ from 'lodash'
 import { checkIsTextNode } from './utils/checkIsTextNode'
 import { VirtualDOM } from './types'
 
-const createDOM = (node: VirtualDOM): HTMLElement | Text => {
+const createDOM = (VDOM: VirtualDOM): HTMLElement | Text => {
+  const { node } = VDOM
+
   if (checkIsTextNode(node)) {
-    if (typeof node === 'object' && node != null) {
+    if (Array.isArray(node)) {
+      return document.createTextNode(node.toString())
+    }
+    if (typeof node === 'object' && node !== null) {
       return document.createTextNode(JSON.stringify(node))
     }
     return document.createTextNode(node == null ? '' : node.toString())
@@ -25,7 +30,9 @@ const createDOM = (node: VirtualDOM): HTMLElement | Text => {
   }
 
   node.children?.forEach((child) => {
-    element.append(createDOM(child))
+    if (child) {
+      element.append(createDOM(child))
+    }
   })
 
   return element

--- a/src/libs/vtu/index.ts
+++ b/src/libs/vtu/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Component } from '@/libs/jsx/jsx-runtime'
 
-import { PageProps, VirtualDOM } from './types'
+import { PageProps } from './types'
 import updateDOM from './updateDOM'
 import shallowEqual from './utils/shallowEquals'
 
@@ -17,8 +17,8 @@ interface RenderObject {
   root?: Component<PageProps>
   $parent?: HTMLElement
   pageParams?: string[]
-  currentVDOM?: VirtualDOM
-  futureVDOM?: VirtualDOM
+  currentVDOM?: JSX.Element
+  futureVDOM?: JSX.Element
 }
 
 function valueToUI() {
@@ -39,11 +39,13 @@ function valueToUI() {
     renderInfo.futureVDOM = renderInfo.root?.({
       pageParams: renderInfo.pageParams,
     })
+
     updateDOM(
       renderInfo.$parent as ChildNode,
       renderInfo.currentVDOM,
       renderInfo.futureVDOM,
     )
+
     renderInfo.currentVDOM = renderInfo.futureVDOM
     values.effectList.forEach((effect) => effect())
   }

--- a/src/libs/vtu/types/index.ts
+++ b/src/libs/vtu/types/index.ts
@@ -1,14 +1,16 @@
-export interface VirtualDOMNode {
+export interface IVirtualDOM {
   tag: keyof HTMLElementTagNameMap
-  props?: Record<string, unknown>
+  props: Record<string, unknown> | null
   children?: VirtualDOM[]
 }
 
 export type TextNode = string | number | Array<unknown> | undefined | null
-export type VirtualDOM = VirtualDOMNode | TextNode
-
+export type VirtualNode = IVirtualDOM | TextNode
+export type VirtualDOM = {
+  node: VirtualNode
+}
 export interface DefaultProps {
-  children?: VirtualDOMNode[]
+  children?: (VirtualDOM | VirtualNode)[]
 }
 
 export interface PageProps extends DefaultProps {

--- a/src/libs/vtu/updateDOM.ts
+++ b/src/libs/vtu/updateDOM.ts
@@ -5,28 +5,30 @@ import { checkIsTextNode } from './utils/checkIsTextNode'
 
 export default function updateDOM(
   $parent: ChildNode,
-  oldNode?: VirtualDOM,
-  newNode?: VirtualDOM,
+  oldVDOM?: VirtualDOM,
+  newVDOM?: VirtualDOM,
   idx = 0,
 ) {
-  if (newNode === undefined) {
-    if (oldNode !== undefined) {
+  if (newVDOM == undefined) {
+    if (oldVDOM != undefined) {
       $parent.removeChild($parent.childNodes[idx])
       return true
     }
     return false
   }
 
-  if (oldNode === undefined) {
-    $parent.appendChild(createDOM(newNode))
+  if (oldVDOM == undefined) {
+    $parent.appendChild(createDOM(newVDOM))
     return false
   }
 
-  if (!checkIsSameVDOM(oldNode, newNode)) {
-    $parent.replaceChild(createDOM(newNode), $parent.childNodes[idx])
+  if (!checkIsSameVDOM(oldVDOM, newVDOM)) {
+    $parent.replaceChild(createDOM(newVDOM), $parent.childNodes[idx])
     return false
   }
 
+  const { node: newNode } = newVDOM
+  const { node: oldNode } = oldVDOM
   if (!checkIsTextNode(newNode) && !checkIsTextNode(oldNode)) {
     const length = Math.max(
       newNode.children?.length ?? 0,

--- a/src/libs/vtu/updateDOM.ts
+++ b/src/libs/vtu/updateDOM.ts
@@ -9,24 +9,20 @@ export default function updateDOM(
   newNode?: VirtualDOM,
   idx = 0,
 ) {
-  if (newNode == null) {
-    if (oldNode != null) {
+  if (newNode === undefined) {
+    if (oldNode !== undefined) {
       $parent.removeChild($parent.childNodes[idx])
       return true
     }
     return false
   }
 
-  if (oldNode == null) {
+  if (oldNode === undefined) {
     $parent.appendChild(createDOM(newNode))
     return false
   }
 
-  if (
-    oldNode != null &&
-    newNode != null &&
-    !checkIsSameVDOM(oldNode, newNode)
-  ) {
+  if (!checkIsSameVDOM(oldNode, newNode)) {
     $parent.replaceChild(createDOM(newNode), $parent.childNodes[idx])
     return false
   }
@@ -38,13 +34,13 @@ export default function updateDOM(
     )
     let nodeDeleteCnt = 0
     for (let i = 0; i < length; i++) {
-      const result = updateDOM(
+      const isNodeDeleted = updateDOM(
         $parent?.childNodes[idx],
         oldNode.children?.[i],
         newNode.children?.[i],
         i - nodeDeleteCnt,
       )
-      if (result) {
+      if (isNodeDeleted) {
         nodeDeleteCnt++
       }
     }

--- a/src/libs/vtu/utils/checkIsSameVDOM.ts
+++ b/src/libs/vtu/utils/checkIsSameVDOM.ts
@@ -3,23 +3,26 @@ import { checkIsTextNode } from './checkIsTextNode'
 import shallowEqual from './shallowEquals'
 
 export function checkIsSameVDOM(current: VirtualDOM, future: VirtualDOM) {
-  if (checkIsTextNode(current)) {
-    if (checkIsTextNode(future)) {
-      return current === future
+  const { node: currentNode } = current
+  const { node: futureNode } = future
+
+  if (checkIsTextNode(currentNode)) {
+    if (checkIsTextNode(futureNode)) {
+      return currentNode === futureNode
     }
 
     return false
   }
 
-  if (checkIsTextNode(future)) {
+  if (checkIsTextNode(futureNode)) {
     return false
   }
 
-  if (current.tag !== future.tag) {
+  if (currentNode.tag !== futureNode.tag) {
     return false
   }
 
-  if (!shallowEqual(current.props, future.props)) {
+  if (!shallowEqual(currentNode.props, futureNode.props)) {
     return false
   }
 

--- a/src/libs/vtu/utils/checkIsTextNode.ts
+++ b/src/libs/vtu/utils/checkIsTextNode.ts
@@ -1,6 +1,6 @@
 import { VirtualDOM, TextNode } from '../types'
 
-export const checkIsTextNode = (element: VirtualDOM): element is TextNode => {
+export function checkIsTextNode(element: VirtualDOM): element is TextNode {
   if (Array.isArray(element)) {
     return true
   }

--- a/src/libs/vtu/utils/checkIsTextNode.ts
+++ b/src/libs/vtu/utils/checkIsTextNode.ts
@@ -1,11 +1,11 @@
-import { VirtualDOM, TextNode } from '../types'
+import { TextNode, VirtualNode } from '../types'
 
-export function checkIsTextNode(element: VirtualDOM): element is TextNode {
+export function checkIsTextNode(element?: VirtualNode): element is TextNode {
   if (Array.isArray(element)) {
     return true
   }
 
-  if (typeof element === 'object' && element != null && element.tag) {
+  if (typeof element === 'object' && element !== null && element.tag) {
     return false
   }
 


### PR DESCRIPTION
## 변경된 것

- useState를 마이크로태스크큐에 넣어서 실행 시점을 모든 컴포넌트 로직이 끝난 후로 변경
- null과 undefined 노드를 처리하기 위해 가상돔을 객체로 한번 감싸줌